### PR TITLE
fix: host path uploads volume for rocketchat in contexts without s3 buckets

### DIFF
--- a/charts/rocketchat/templates/rocketchat-deployment.yaml
+++ b/charts/rocketchat/templates/rocketchat-deployment.yaml
@@ -71,7 +71,7 @@ spec:
               name: rocketchat-user-uploads
           {{- end }}
       restartPolicy: Always
-      {{- if .Values.global.initializeDummyData }}
+      {{- if or .Values.global.initializeDummyData .Values.useHostpathUploadStorage }}
       volumes:
         {{- if .Values.useHostpathUploadStorage }}
         - name: rocketchat-app-uploads
@@ -81,7 +81,9 @@ spec:
           persistentVolumeClaim:
             claimName: rocketchat-user-uploads
         {{- end }}
+        {{- if .Values.global.initializeDummyData }}
         - name: plattform-init-data
           persistentVolumeClaim:
             claimName: plattform-initialization-data
+        {{- end }}
       {{- end }}


### PR DESCRIPTION
Fixes # helm upgrade error for th koeln and all other environments where rocketchat uploads are not stored in s3 bucket