### PR TITLE
feat: added ability to limit wiredtiger cache size

### DIFF
--- a/charts/mongodb/templates/mongodb-statefulset.yaml
+++ b/charts/mongodb/templates/mongodb-statefulset.yaml
@@ -40,6 +40,8 @@ spec:
           - rs0
           - --keyFile
           - /data/key/replica.key
+          - --wiredTigerCacheSizeGB
+          - {{ .Values.wiredTigerCacheSizeGB }}
           env:
             - name: MONGO_INITDB_ROOT_PASSWORD
               valueFrom:

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -3,6 +3,7 @@ mongoVersion: "6.0"
 mongoSharedKey: "default"
 
 mongoDbDataStorage: "1Gi"
+wiredTigerCacheSizeGB: "5"
 
 global:
   mongoInitDbRootUsername: "admin"


### PR DESCRIPTION
## Proposed Changes
Added ability to limit wiredtiger cache size because it will use by default  (ram - 1GB) / 2 of the system memory not the container itself.