### PR TITLE
fix: DELPHI-380

### DIFF
--- a/customization/keycloak-resources/custom-theme/login/messages/messages_de.properties
+++ b/customization/keycloak-resources/custom-theme/login/messages/messages_de.properties
@@ -34,7 +34,7 @@ errorTitleHtml=Es ist ein Fehler aufgetreten.
 emailVerifyTitle=E-Mail verifizieren
 emailForgotTitle=Passwort vergessen?
 updatePasswordTitle=Passwort zur\u00FCcksetzen
-updatePasswordInfoText=W\u00E4hlen Sie bitte ein Passwort mit mind. 10 Zeichen, einer Zahl und einem Sonderzeichen, um Ihre Daten optimal zu sch\u00FCtzen.
+updatePasswordInfoText=W\u00E4hlen Sie bitte ein Passwort mit mind. 9 Zeichen, einer Zahl und einem Sonderzeichen, um Ihre Daten optimal zu sch\u00FCtzen.
 codeSuccessTitle=Erfolgreicher Code
 codeErrorTitle=Fehlercode\: {0}
 

--- a/customization/keycloak-resources/custom-theme/login/messages/messages_en.properties
+++ b/customization/keycloak-resources/custom-theme/login/messages/messages_en.properties
@@ -1,2 +1,2 @@
-updatePasswordInfoText=Please choose a password of at least ten characters, one digit, and one special character to assure your data is safe.
+updatePasswordInfoText=Please choose a password of at least 9 characters, one digit, and one special character to assure your data is safe.
 emailVerifyInstruction1=An email with instructions to reset your password has been sent to your address.


### PR DESCRIPTION
Update messages.properties files update password text to clear display the 9-min characters instead of 10

Fixes #

## Proposed Changes

  -
  -
  -
